### PR TITLE
Allow the use of non persistable entities

### DIFF
--- a/src/CellStyler/CellStyler.xml
+++ b/src/CellStyler/CellStyler.xml
@@ -8,7 +8,7 @@
             <category>Behavior</category>
             <description>Name of the data grid widget.</description>
         </property>
-		<property key="gridEntity" type="entity" required="true">
+		<property key="gridEntity" type="entity" required="true" allowNonPersistableEntities="true">
 		    <caption>Grid Entity</caption>
 			<category>Behavior</category>
 	 		<description>The type of objects in the grid.</description>


### PR DESCRIPTION
I noticed I could not use the widget with a non persistable entity, although I do not see any technical issues with it for this widget.

The allowNonPersistableEntities property is defaulted to false. I set it to true in the CellStyler.xml and the widget worked for my non persistable entity.